### PR TITLE
Windows support

### DIFF
--- a/src/edu/semeru/android/capture/controller/Controller.java
+++ b/src/edu/semeru/android/capture/controller/Controller.java
@@ -275,8 +275,8 @@ public class Controller {
     public static File createConfigFile(String androidSdkPath, String aaptPath, String apkPath, String getEventFilePath,
                                         String outputPath, int avdPort, int adbPort, int executionNum) throws IOException {
         
-        String pythonScriptsPath = String.format("%s/lib/python-scripts/", System.getProperty("user.dir"));
-        FileWriter configFileWriter = new FileWriter(outputPath + "/config.yaml");
+        String pythonScriptsPath = String.format("%s" + File.separator + "lib" + File.separator + "python-scripts" + File.separator, System.getProperty("user.dir"));
+        FileWriter configFileWriter = new FileWriter(outputPath + File.separator + "config.yaml");
         configFileWriter.write("androidSDKPath: " + androidSdkPath + "\n");
         configFileWriter.write("pythonScriptsPath: " + pythonScriptsPath + "\n");
         configFileWriter.write("aaptPath: " + aaptPath + "\n");

--- a/src/edu/semeru/android/capture/controller/Controller.java
+++ b/src/edu/semeru/android/capture/controller/Controller.java
@@ -288,7 +288,7 @@ public class Controller {
         configFileWriter.write("executionNum: " + executionNum + "\n");
         configFileWriter.close();
 
-        File configFileHandle = new File(outputPath + "/config.yaml");
+        File configFileHandle = new File(outputPath + File.separator + "config.yaml");
         return configFileHandle;
     }
     


### PR DESCRIPTION
## Description

The jar file `trace-replayer.jar` was updated to support Windows machines as well

## Changes
Modified `trace-replayer.jar` to be able to grab information with Windows tooling if ran on a Windows machine.

## Testing
- Built the tool on both a Windows machine and Linux machine with `mvn clean && mvn package`.
- Moved the jar executable from the `target/` folder into the root directory, and ran it with the command `java -jar`.
- Installed Firefox Klar-v125.3.0 APK (https://github.com/mozilla-mobile/firefox-android/releases) onto the Android Emulator in Android Studio.
- Started the Firefox Klar app in the emulator, and waited on the initial screen.
- Set up all the file paths in the Android Video Capture Tool and hit start.
- Waited 5 seconds, then started clicking/tapping through the Klar app.
- Hit Stop on the AVT tool, then hit Next and filled out all of the file paths.
- Hit Start Trace Replayer, and double-checked that the tool created a Execution-1.json file in the specified output folder.